### PR TITLE
Ensure package name is always configured

### DIFF
--- a/src/LaravelConfigCheckerServiceProvider.php
+++ b/src/LaravelConfigCheckerServiceProvider.php
@@ -10,9 +10,10 @@ class LaravelConfigCheckerServiceProvider extends PackageServiceProvider
 {
     public function configurePackage(Package $package): void
     {
+        $package->name('laravel-config-checker');
+
         if ($this->app->runningInConsole()) {
             $package
-                ->name('laravel-config-checker')
                 ->hasCommand(LaravelConfigCheckerCommand::class);
         }
     }


### PR DESCRIPTION
This PR fixes an issue with the package configuration when registered in a non-console context.  The package name was not configured correctly unless run from the console.

This closes #2 .
