### PR TITLE
Don't check internal methods called config

### DIFF
--- a/src/Support/FileChecker.php
+++ b/src/Support/FileChecker.php
@@ -60,7 +60,7 @@ class FileChecker
     {
         $matches = [];
 
-        preg_match_all('/config\([\'"]([^\'"]+)[\'"]\)/', $content, $matches, PREG_OFFSET_CAPTURE);
+        preg_match_all('/[^:>]config\([\'"]([^\'"]+)[\'"]\)/', $content, $matches, PREG_OFFSET_CAPTURE);
 
         $issues = [];
 

--- a/tests/FileCheckerTest.php
+++ b/tests/FileCheckerTest.php
@@ -214,3 +214,25 @@ it('detects issues for invalid nested keys', function () {
     expect($issues->contains('key', 'file.valid_key'))->toBeFalse();
     expect($issues->contains('key', 'file.nested.invalid_key'))->toBeTrue();
 });
+
+it('ignores methods called config', function () {
+    $content = <<<'PHP'
+        <?php
+            $this->config("some-invalid-key");
+            SomeClass::config("another.invalid-key");
+            config('some.random.key');
+            Config::has('some.invalid.key');
+            Config::get('some.other.invalid.key');
+        PHP;
+
+    $fileChecker = new FileChecker($this->configKeys, $content);
+
+    $issues = $fileChecker->check();
+
+    expect($issues->count())->toBe(3);
+    expect($issues->contains('key', 'some.random.key'))->toBeTrue();
+    expect($issues->contains('key', 'some.invalid.key'))->toBeTrue();
+    expect($issues->contains('key', 'some.other.invalid.key'))->toBeTrue();
+    expect($issues->contains('key', 'some-invalid-key'))->toBeFalse();
+    expect($issues->contains('key', 'another.invalid-key'))->toBeFalse();
+});


### PR DESCRIPTION
```php
class MyClass
{
    public function doSomething()
    {
        return $this->config('key');
    }

    private function config(string $key)
    {
        return config('path.to.' . $key);
    }
}
```

- Before - fails
- After - passes