### PR TITLE
Refactor to check config directly

### DIFF
--- a/src/Commands/LaravelConfigCheckerCommand.php
+++ b/src/Commands/LaravelConfigCheckerCommand.php
@@ -7,7 +7,6 @@ namespace ChrisDiCarlo\LaravelConfigChecker\Commands;
 use ChrisDiCarlo\LaravelConfigChecker\Resolvers\BladeFileResolver;
 use ChrisDiCarlo\LaravelConfigChecker\Resolvers\PhpFileResolver;
 use ChrisDiCarlo\LaravelConfigChecker\Support\FileChecker;
-use ChrisDiCarlo\LaravelConfigChecker\Support\LoadConfigKeys;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 
@@ -26,8 +25,6 @@ class LaravelConfigCheckerCommand extends Command
 
     public $description = 'Check all references to config values in PHP and Blade files';
 
-    private Collection $configKeys;
-
     private array $bladeIssues = [];
 
     private array $phpIssues = [];
@@ -41,12 +38,9 @@ class LaravelConfigCheckerCommand extends Command
     }
 
     public function handle(
-        LoadConfigKeys $loadConfigKeys,
         PhpFileResolver $phpFiles,
         BladeFileResolver $bladeFiles
     ): int {
-        $this->configKeys = $loadConfigKeys();
-
         if ($this->option('no-progress')) {
             intro('--no-progress option used. Disabling progress bar.');
 
@@ -57,7 +51,7 @@ class LaravelConfigCheckerCommand extends Command
                 foreach ($phpFiles as $file) {
                     $content = file_get_contents($file->getRealPath());
 
-                    $fileChecker = new FileChecker($this->configKeys, $content);
+                    $fileChecker = new FileChecker($content);
 
                     foreach ($fileChecker->check() as $issue) {
                         $this->phpIssues[$file->getRelativePathname()][] = $issue;
@@ -70,7 +64,7 @@ class LaravelConfigCheckerCommand extends Command
                 $bladeFiles = $bladeFiles->resolve();
                 foreach ($bladeFiles as $file) {
                     $content = file_get_contents($file->getRealPath());
-                    $fileChecker = new FileChecker($this->configKeys, $content);
+                    $fileChecker = new FileChecker($content);
 
                     foreach ($fileChecker->check() as $issue) {
                         $this->bladeIssues[$file->getRelativePathname()][] = $issue;
@@ -87,7 +81,7 @@ class LaravelConfigCheckerCommand extends Command
 
                         $content = file_get_contents($file->getRealPath());
 
-                        $fileChecker = new FileChecker($this->configKeys, $content);
+                        $fileChecker = new FileChecker($content);
 
                         foreach ($fileChecker->check() as $issue) {
                             $this->phpIssues[$file->getRelativePathname()][] = $issue;
@@ -104,7 +98,7 @@ class LaravelConfigCheckerCommand extends Command
                         $progress->hint = "Checking {$file->getRelativePathname()}";
 
                         $content = file_get_contents($file->getRealPath());
-                        $fileChecker = new FileChecker($this->configKeys, $content);
+                        $fileChecker = new FileChecker($content);
 
                         foreach ($fileChecker->check() as $issue) {
                             $this->bladeIssues[$file->getRelativePathname()][] = $issue;

--- a/src/Support/FileChecker.php
+++ b/src/Support/FileChecker.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace ChrisDiCarlo\LaravelConfigChecker\Support;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
 
 class FileChecker
 {
     public function __construct(
-        private readonly Collection $configKeys,
         private readonly string $content,
     ) {}
 
@@ -46,7 +46,7 @@ class FileChecker
             $offset = (int) $match[1];
             $lineNumber = substr_count(substr($content, 0, $offset), "\n") + 1;
 
-            if ($this->configKeys->doesntContain($key)) {
+            if (! Config::has($key)) {
                 $issues[] = [
                     'key' => $key,
                     'type' => sprintf('Config::%s()', $matches[1][$index][0]),
@@ -71,7 +71,7 @@ class FileChecker
             $offset = (int) $match[1];
             $lineNumber = substr_count(substr($content, 0, $offset), "\n") + 1;
 
-            if ($this->configKeys->doesntContain($key)) {
+            if (! Config::has($key)) {
                 $issues[] = [
                     'key' => $key,
                     'type' => 'config()',

--- a/tests/LaravelConfigCheckerCommandTest.php
+++ b/tests/LaravelConfigCheckerCommandTest.php
@@ -2,11 +2,16 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Config;
+
 use function Pest\Laravel\artisan;
 
 it('displays a message when there are no issues', function () {
-    // set the base path for the application
     $this->app->setBasePath(realpath(__DIR__ . '/fixtures/valid'));
+    Config::set('app.valid_key', 'Laravel Config Checker');
+    Config::set('app.nested', [
+        'key' => 'value',
+    ]);
 
     artisan('config:check')
         ->expectsOutputToContain('No issues found. All config references are valid.')
@@ -14,8 +19,12 @@ it('displays a message when there are no issues', function () {
 });
 
 it('displays a message when there are issues', function () {
-    // set the base path for the application
     $this->app->setBasePath(realpath(__DIR__ . '/fixtures/invalid'));
+
+    Config::set('app.valid_key', 'Laravel Config Checker');
+    Config::set('app.nested', [
+        'key' => 'value',
+    ]);
 
     artisan('config:check')
         ->expectsOutputToContain('Invalid config references found:')
@@ -29,6 +38,11 @@ it('displays a message when there are issues', function () {
 it('disables the progress bar when the --no-progress option is used', function () {
     $this->app->setBasePath(realpath(__DIR__ . '/fixtures/valid'));
 
+    Config::set('app.valid_key', 'Laravel Config Checker');
+    Config::set('app.nested', [
+        'key' => 'value',
+    ]);
+
     artisan('config:check', ['--no-progress' => true])
         ->expectsOutputToContain('--no-progress option used. Disabling progress bar.')
         ->expectsOutputToContain('Checking PHP files...')
@@ -39,6 +53,11 @@ it('disables the progress bar when the --no-progress option is used', function (
 
 it('skips checking blade files when the --no-blade option is used', function () {
     $this->app->setBasePath(realpath(__DIR__ . '/fixtures/valid'));
+
+    Config::set('app.valid_key', 'Laravel Config Checker');
+    Config::set('app.nested', [
+        'key' => 'value',
+    ]);
 
     artisan('config:check', ['--no-blade' => true])
         ->expectsOutputToContain('Checking PHP files...')
@@ -55,6 +74,11 @@ it('skips checking blade files when the --no-blade option is used', function () 
 
 it('skips checking php files when the --no-php option is used', function () {
     $this->app->setBasePath(realpath(__DIR__ . '/fixtures/valid'));
+
+    Config::set('app.valid_key', 'Laravel Config Checker');
+    Config::set('app.nested', [
+        'key' => 'value',
+    ]);
 
     artisan('config:check', ['--no-php' => true])
         ->expectsOutputToContain('Checking Blade files...')


### PR DESCRIPTION
This PR fixes an issue where config keys were sometimes incorrectly checked if they did not exist in the user's config directory.

It now checks the config instance directly for the existence of the key rather than parsing the configuration files.  This change facilitates checking non-published configurations from packages.
