### PR TITLE
feat: add configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ You can install the package via composer:
 composer require chrisdicarlo/laravel-config-checker
 ```
 
+After installing the package, you can publish the configuration file:
+
+```bash
+php artisan vendor:publish --tag="config-checker-config"
+```
 
 ## Usage
 From the command-line, simply run:
@@ -27,9 +32,15 @@ From the command-line, simply run:
 php artisan config:check
 ```
 
-The command will scan your Php code under `app`, `database`, `routes`, `bootstrap` and your Blade views under `resources/views`.  Any errors will be displayed in a table with information on the location and missing reference:
+The command will scan your Php code under `app`, `database`, `routes`, `bootstrap` and your Blade views under `resources/views`.  
+Any errors will be displayed in a table with information on the location and missing reference:
 
 ![Sample Output](output-sample.png)
+
+### Customizing paths
+
+If you want the command to scan PHP/Blade code under custom paths, you can add or update entries in
+`config/config-checker.php`.
 
 ### Disabling progress
 

--- a/config/config-checker.php
+++ b/config/config-checker.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'blade' => [
+        'include_paths' => [
+            'resources/views',
+        ],
+
+        'exclude_paths' => [
+            'vendor',
+        ],
+
+        'names' => [
+            '*.blade.php',
+        ],
+    ],
+
+    'config' => [
+        'include_paths' => [
+            'config',
+        ],
+
+        'exclude_paths' => [
+            'vendor',
+        ],
+
+        'names' => [
+            '*.php',
+        ],
+    ],
+
+    'php' => [
+        'include_paths' => [
+            'app',
+            'database',
+            'routes',
+            'bootstrap',
+        ],
+
+        'exclude_paths' => [
+            'config',
+            'vendor',
+        ],
+
+        'names' => [
+            '*.php',
+        ],
+    ],
+];

--- a/src/LaravelConfigCheckerServiceProvider.php
+++ b/src/LaravelConfigCheckerServiceProvider.php
@@ -14,6 +14,8 @@ class LaravelConfigCheckerServiceProvider extends PackageServiceProvider
     {
         $package->name('laravel-config-checker');
 
+        $package->hasConfigFile();
+
         if ($this->app->runningInConsole()) {
             $package->hasCommand(LaravelConfigCheckerCommand::class);
         }

--- a/src/Resolvers/BladeFileResolver.php
+++ b/src/Resolvers/BladeFileResolver.php
@@ -8,16 +8,16 @@ class BladeFileResolver extends AbstractFileResolver
 {
     public function excludePaths(): array
     {
-        return ['vendor'];
+        return config('config-checker.blade.exclude_paths');
     }
 
     public function includePaths(): array
     {
-        return ['resources/views'];
+        return config('config-checker.blade.include_paths');
     }
 
     public function names(): array
     {
-        return ['*.blade.php'];
+        return config('config-checker.blade.names');
     }
 }

--- a/src/Resolvers/ConfigFileResolver.php
+++ b/src/Resolvers/ConfigFileResolver.php
@@ -8,16 +8,16 @@ class ConfigFileResolver extends AbstractFileResolver
 {
     public function excludePaths(): array
     {
-        return ['vendor'];
+        return config('config-checker.config.exclude_paths');
     }
 
     public function includePaths(): array
     {
-        return ['config'];
+        return config('config-checker.config.include_paths');
     }
 
     public function names(): array
     {
-        return ['*.php'];
+        return config('config-checker.config.names');
     }
 }

--- a/src/Resolvers/PhpFileResolver.php
+++ b/src/Resolvers/PhpFileResolver.php
@@ -8,16 +8,16 @@ class PhpFileResolver extends AbstractFileResolver
 {
     public function excludePaths(): array
     {
-        return ['vendor', 'config'];
+        return config('config-checker.php.exclude_paths');
     }
 
     public function includePaths(): array
     {
-        return ['app', 'database', 'routes', 'bootstrap'];
+        return config('config-checker.php.include_paths');
     }
 
     public function names(): array
     {
-        return ['*.php'];
+        return config('config-checker.php.names');
     }
 }


### PR DESCRIPTION
This PR adds a **configuration file**, allowing the user to customize paths where the command will check for configurations.

Using a configuration file, the command can scan non-standard paths. For example, I use a domain-oriented folder structure like this:

```
./src/App
./src/Domain
```

In such a scenario, I can use `src` instead of `app` in the config file:

```php
<?php

declare(strict_types=1);

return [
    'blade' => [
        'include_paths' => [
            'resources/views',
        ],

        'exclude_paths' => [
            'vendor',
        ],

        'names' => [
            '*.blade.php',
        ],
    ],

    'config' => [
        'include_paths' => [
            'config',
        ],

        'exclude_paths' => [
            'vendor',
        ],

        'names' => [
            '*.php',
        ],
    ],

    'php' => [
        'include_paths' => [
            'src',
            'database',
            'routes',
            'bootstrap',
        ],

        'exclude_paths' => [
            'config',
            'vendor',
        ],

        'names' => [
            '*.php',
        ],
    ],
];
```