### PR TITLE
Fix potential bug if Blade and PHP files are colocated

### DIFF
--- a/config/config-checker.php
+++ b/config/config-checker.php
@@ -11,10 +11,6 @@ return [
         'exclude_paths' => [
             'vendor',
         ],
-
-        'names' => [
-            '*.blade.php',
-        ],
     ],
 
     'config' => [
@@ -24,10 +20,6 @@ return [
 
         'exclude_paths' => [
             'vendor',
-        ],
-
-        'names' => [
-            '*.php',
         ],
     ],
 
@@ -42,10 +34,6 @@ return [
         'exclude_paths' => [
             'config',
             'vendor',
-        ],
-
-        'names' => [
-            '*.php',
         ],
     ],
 ];

--- a/src/Contracts/FileResolverContract.php
+++ b/src/Contracts/FileResolverContract.php
@@ -13,4 +13,6 @@ interface FileResolverContract
     public function names(): array;
 
     public function resolve(): iterable;
+
+    public function excludeNames(): array;
 }

--- a/src/Resolvers/AbstractFileResolver.php
+++ b/src/Resolvers/AbstractFileResolver.php
@@ -28,6 +28,11 @@ abstract class AbstractFileResolver implements FileResolverContract
 
     abstract public function names(): array;
 
+    public function excludeNames(): array
+    {
+        return [];
+    }
+
     public function resolve(): iterable
     {
         if (! $this->finder) {
@@ -53,6 +58,10 @@ abstract class AbstractFileResolver implements FileResolverContract
 
         foreach ($this->names() as $name) {
             $finder->name($name);
+        }
+
+        foreach ($this->excludeNames() as $excludeName) {
+            $finder->notName($excludeName);
         }
 
         return $finder;

--- a/src/Resolvers/BladeFileResolver.php
+++ b/src/Resolvers/BladeFileResolver.php
@@ -18,6 +18,6 @@ class BladeFileResolver extends AbstractFileResolver
 
     public function names(): array
     {
-        return config('config-checker.blade.names');
+        return ['*.blade.php'];
     }
 }

--- a/src/Resolvers/ConfigFileResolver.php
+++ b/src/Resolvers/ConfigFileResolver.php
@@ -18,6 +18,11 @@ class ConfigFileResolver extends AbstractFileResolver
 
     public function names(): array
     {
-        return config('config-checker.config.names');
+        return ['*.php'];
+    }
+
+    public function excludeNames(): array
+    {
+        return ['*.blade.php'];
     }
 }

--- a/src/Resolvers/PhpFileResolver.php
+++ b/src/Resolvers/PhpFileResolver.php
@@ -18,6 +18,11 @@ class PhpFileResolver extends AbstractFileResolver
 
     public function names(): array
     {
-        return config('config-checker.php.names');
+        return ['*.php'];
+    }
+
+    public function excludeNames(): array
+    {
+        return ['*.blade.php'];
     }
 }


### PR DESCRIPTION
This pull request refactors how file name patterns are managed for file resolvers in the config checker system. The introduction of the config file added the `names` key, but it is not necessary given the file extensions are static.

## Changes
* Moved file name extensions into code.
* Added support for excluding specific file name patterns directly in resolver classes to stop the possibility of a file showing up as both a PHP file and a Blade file.