### PR TITLE
test: update tests PHP matrix for version 8.5

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.5, 8.4, 8.3, 8.2, 8.1]
@@ -39,6 +39,7 @@ jobs:
             php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    continue-on-error: ${{ matrix.php == '8.5' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3, 8.2, 8.1]
+        php: [8.5, 8.4, 8.3, 8.2, 8.1]
         laravel: [12.*, 11.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
@@ -31,6 +31,8 @@ jobs:
             testbench: 8.*
             carbon: ^2.63
         exclude:
+          - laravel: 10.*
+            php: 8.5
           - laravel: 11.*
             php: 8.1
           - laravel: 12.*

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,14 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "spatie/laravel-package-tools": "^1.16",
         "illuminate/contracts": "^10.0||^11.0||^12.0"
     },
     "require-dev": {
+        "brianium/paratest": "^7.3.1",
         "laravel/pint": "^1.14",
+        "nesbot/carbon": "^2.63||^3.0",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "orchestra/testbench": "^10.0||^9.0.0||^8.22.0",
         "pestphp/pest": "^3.8||^2.34",


### PR DESCRIPTION
This pull request updates the project's testing configuration and dependencies to improve compatibility with newer PHP versions and Laravel releases. The most significant changes are in the test matrix and dependency requirements.

**Testing matrix updates:**

* Added support for PHP 8.5 in the GitHub Actions test matrix, while excluding incompatible combinations (e.g., Laravel 10.* with PHP 8.5) and allowing tests to continue on error for PHP 8.5. [[1]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L17-R20) [[2]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642R34-R42)
* Changed `fail-fast` to `false` in the test matrix to allow all test jobs to run even if some fail.

**Dependency updates:**

* Increased the minimum required PHP version to 8.1 in `composer.json`.
* Added `brianium/paratest` as a dev dependency for parallel testing.
* Updated the `nesbot/carbon` dev dependency to support both major versions 2 and 3.